### PR TITLE
aspnet beta4 no longer available

### DIFF
--- a/aspnetbase/Dockerfile
+++ b/aspnetbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnet:1.0.0-rc1-update1
+FROM microsoft/aspnet:1.0.0-beta6
 ADD /src /app
 WORKDIR /app
 RUN ["dnu", "restore"]

--- a/aspnetbase/Dockerfile
+++ b/aspnetbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnet:1.0.0-beta4
+FROM microsoft/aspnet:1.0.0-rc1-update1
 ADD /src /app
 WORKDIR /app
 RUN ["dnu", "restore"]

--- a/aspnetbase/src/project.json
+++ b/aspnetbase/src/project.json
@@ -3,10 +3,10 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.Server.IIS": "1.0.0-beta4",
-    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4",
-    "Microsoft.AspNet.Mvc": "6.0.0-beta4",
-    "Kestrel" : "1.0.0-beta4"
+    "Microsoft.AspNet.Server.IIS": "1.0.0-beta6",
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta6",
+    "Microsoft.AspNet.Mvc": "6.0.0-beta6",
+    "Kestrel" : "1.0.0-beta6"
   },
 
   "commands": {

--- a/calculator/Dockerfile
+++ b/calculator/Dockerfile
@@ -1,4 +1,4 @@
-FROM aspnetbase:beta4
+FROM aspnetbase:1.0.0-beta6
 ADD /src /app
 WORKDIR /app
 RUN ["dnu", "restore"]

--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM aspnetbase:beta4
+FROM aspnetbase:1.0.0-beta6
 ADD /src /app
 WORKDIR /app
 RUN ["dnu", "restore"]

--- a/optimizer/src/project.json
+++ b/optimizer/src/project.json
@@ -3,10 +3,10 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.Server.IIS": "1.0.0-beta4",
-    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4",
-    "Microsoft.AspNet.Mvc": "6.0.0-beta4",
-    "Kestrel" : "1.0.0-beta4"
+    "Microsoft.AspNet.Server.IIS": "1.0.0-beta6",
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta6",
+    "Microsoft.AspNet.Mvc": "6.0.0-beta6",
+    "Kestrel" : "1.0.0-beta6"
   },
 
   "commands": {


### PR DESCRIPTION
_beta4_ is no longer available (see https://hub.docker.com/r/microsoft/aspnet/)

```
[gpouillo@kactus] aspnetbase $ docker build -t aspnetbase:beta4 .
Sending build context to Docker daemon 4.096 kB
Step 1 : FROM microsoft/aspnet:1.0.0-beta4
Pulling repository docker.io/microsoft/aspnet
Tag 1.0.0-beta4 not found in repository docker.io/microsoft/aspnet
```

A release candidate has been released so updating to this version as a workaround for the issue identified
